### PR TITLE
Improve Nearest Neighbor Lookup

### DIFF
--- a/src/ECCO_advect_2D.py
+++ b/src/ECCO_advect_2D.py
@@ -7,7 +7,7 @@ import xarray as xr
 import pandas as pd
 from datetime import timedelta
 from opencl_driver_2D import openCL_advect
-from plot_advection import plot_advection, plot_ocean_advection
+from plot_advection import plot_ocean_advection
 from dask.diagnostics import ProgressBar
 
 

--- a/src/kernels/eulerian_kernel_2d.cl
+++ b/src/kernels/eulerian_kernel_2d.cl
@@ -1,13 +1,13 @@
-unsigned int find_nearest_neighbor_idx(float value, __global float* arr, const unsigned int arr_len, const float spacing);
+unsigned int find_nearest_neighbor_idx(double value, __global double* arr, const unsigned int arr_len, const double spacing);
 
 __kernel void advect(
-    __global float* field_x,    // lon, Deg E (-180 to 180), uniform spacing
-    const unsigned int x_len,   // <= UINT_MAX
-    __global float* field_y,    // lat, Deg N (-90 to 90), uniform spacing
-    const unsigned int y_len,   // <= UINT_MAX
-    __global float* field_t,    // time, unix timestamp, uniform spacing
-    const unsigned int t_len,   // <= UINT_MAX
-    __global float* field_U,    // m / s
+    __global double* field_x,    // lon, Deg E (-180 to 180), uniform spacing
+    const unsigned int x_len,   // <= UINT_MAX + 1
+    __global double* field_y,    // lat, Deg N (-90 to 90), uniform spacing
+    const unsigned int y_len,   // <= UINT_MAX + 1
+    __global double* field_t,     // time, seconds since epoch, uniform spacing
+    const unsigned int t_len,   // <= UINT_MAX + 1
+    __global float* field_U,    // m / s, 32 bit to save space
     __global float* field_V,    // m / s
     __global float* x0,         // lon, Deg E (-180 to 180)
     __global float* y0,         // lat, Deg N (-90 to 90)
@@ -22,14 +22,14 @@ __kernel void advect(
     const unsigned int out_timesteps = ntimesteps / save_every;
 
     // calculate spacing of grids
-    const float x_spacing = field_x[1]-field_x[0];
-    const float y_spacing = field_y[1]-field_y[0];
-    const float t_spacing = field_t[1]-field_t[0];
+    const double x_spacing = field_x[1]-field_x[0];
+    const double y_spacing = field_y[1]-field_y[0];
+    const double t_spacing = field_t[1]-field_t[0];
 
     // loop timesteps
-    float x = x0[p_id];
-    float y = y0[p_id];
-    float t = t0[p_id];
+    double x = x0[p_id];
+    double y = y0[p_id];
+    double t = t0[p_id];
     for (unsigned int timestep=0; timestep<ntimesteps; timestep++) {
 
         // find nearest neighbors in grid
@@ -77,9 +77,9 @@ __kernel void advect(
     }
 }
 
-unsigned int find_nearest_neighbor_idx(float value, __global float* arr, const unsigned int arr_len, const float spacing) {
+unsigned int find_nearest_neighbor_idx(double value, __global double* arr, const unsigned int arr_len, const double spacing) {
     // assumption: arr is sorted with uniform spacing.  Actually works on ascending or descending sorted arr.
     // also, we must have arr_len - 1 <= UINT_MAX for the cast of the clamp result to behave properly.  Can't raise errors
     // inside a kernel so we must perform the check in the host code.
-    return (unsigned int) clamp(round((value - arr[0])/spacing), (float) (0.0), (float) (arr_len-1));
+    return (unsigned int) clamp(round((value - arr[0])/spacing), (double) (0.0), (double) (arr_len-1));
 }

--- a/src/kernels/eulerian_kernel_check_host_args_2d.py
+++ b/src/kernels/eulerian_kernel_check_host_args_2d.py
@@ -1,0 +1,38 @@
+"""
+Since we can't raise errors inside kernels, the best practice is to create an arg-checking function which accompanies
+every kernel.  Before calling any kernel, its arg-check function should be called.
+"""
+import opencl_specification_constants as cl_const
+import numpy as np
+
+
+def check_args(field_x, x_len,
+               field_y, y_len,
+               field_t, t_len,
+               field_U, field_V,
+               x0, y0, t0,
+               dt, ntimesteps, save_every,
+               X_out, Y_out):
+    assert max(field_x) < 180
+    assert min(field_x) >= -180
+    assert len(field_x) <= cl_const.UINT_MAX + 1
+    assert is_uniformly_spaced(field_x)
+
+    assert max(field_y) < 90
+    assert min(field_y) >= -90
+    assert len(field_y) <= cl_const.UINT_MAX + 1
+    assert is_uniformly_spaced(field_y)
+
+    assert len(field_t) <= cl_const.UINT_MAX + 1
+    assert is_uniformly_spaced(field_t)
+
+    assert max(x0) < 180
+    assert min(x0) >= -180
+
+    assert max(y0) < 90
+    assert min(y0) >= -90
+
+
+def is_uniformly_spaced(arr):
+    tol = 1e-5
+    return all(np.abs(np.diff(arr) - np.diff(arr)[0]) < tol)

--- a/src/opencl_driver_2D.py
+++ b/src/opencl_driver_2D.py
@@ -3,18 +3,21 @@ import numpy as np
 import time
 import xarray as xr
 import pandas as pd
+from kernels.eulerian_kernel_check_host_args_2d import check_args
 
 from typing import Tuple
 
 
-def openCL_advect(field: xr.DataArray,
+def openCL_advect(field: xr.Dataset,
                   p0: pd.DataFrame,
                   advect_time: pd.DatetimeIndex,
                   save_every: int,
                   platform_and_device: Tuple[int, int] = None,
                   verbose=False):
     """
-    :param field: xarray DatArray storing vector field/axes.
+    :param field: xarray Dataset storing vector field/axes.
+                    Dimensions: {'time', 'lon', 'lat'}
+                    Variables: {'U', 'V'}
     :param p0: initial positions of particles, numpy array shape (num_particles, 2)
     :param advect_time: pandas DatetimeIndex corresponding to the timeseries which the particles will be advected over
     :param save_every: how many timesteps between saving state.  Must divide num_timesteps.
@@ -24,16 +27,14 @@ def openCL_advect(field: xr.DataArray,
                                                    time it took to transfer memory to/from device,
                                                    time it took to execute kernel on device)
     """
-    # checks
-    assert np.all(np.diff(advect_time) == advect_time[1] - advect_time[0]), "advect timeseries must have all equal timesteps"
-
     field = field.transpose('time', 'lon', 'lat')  # make sure the underlying numpy arrays are in the correct shape
-    field['time'] = (field.time - np.datetime64('1970-01-01')) / np.timedelta64(1, 's')  # convert field's time axis to unix timestamp
+    field['time'] = (field.time - np.datetime64('1970-01-01')) / np.timedelta64(1,
+                                                                                's')  # convert field's time axis to unix timestamp
     num_timesteps = len(advect_time)
     t0 = advect_time[0].timestamp()  # unix timestamp
-    dt = (advect_time[1]-advect_time[0]).total_seconds()
+    dt = (advect_time[1] - advect_time[0]).total_seconds()
     num_particles = len(p0)
-    out_timesteps = num_timesteps//save_every
+    out_timesteps = num_timesteps // save_every
 
     # -----------OPENCL BOILERPLATE------------
     # Create a compute context
@@ -48,16 +49,16 @@ def openCL_advect(field: xr.DataArray,
 
     # Create the compute program from the source buffer
     # and build it
-    program = cl.Program(context, open('kernels/2d_eulerian_kernel.cl').read()).build()
+    program = cl.Program(context, open('kernels/eulerian_kernel_2d.cl').read()).build()
 
     # initialize host vectors
-    h_field_x = field.lon.astype(np.float32).values
-    h_field_y = field.lat.astype(np.float32).values
-    h_field_t = field.time.astype(np.float32).values
-    h_field_U = field.U.astype(np.float32).values.flatten()
-    h_field_V = field.V.astype(np.float32).values.flatten()
-    h_x0 = p0.lon.astype(np.float32).values
-    h_y0 = p0.lat.astype(np.float32).values
+    h_field_x = field.lon.values.astype(np.float64)
+    h_field_y = field.lat.values.astype(np.float64)
+    h_field_t = field.time.values.astype('datetime64[s]').astype(np.float64)
+    h_field_U = field.U.values.astype(np.float32).flatten()
+    h_field_V = field.V.values.astype(np.float32).flatten()
+    h_x0 = p0.lon.values.astype(np.float32)
+    h_y0 = p0.lat.values.astype(np.float32)
     h_t0 = (t0 * np.ones(num_particles)).astype(np.float32)
     h_X_out = np.zeros(num_particles * out_timesteps).astype(np.float32)
     h_Y_out = np.zeros(num_particles * out_timesteps).astype(np.float32)
@@ -71,22 +72,28 @@ def openCL_advect(field: xr.DataArray,
             print(f'{buf_name}: {buf_value.nbytes / 1e6} MB')
 
     buf_time = time.time()
+
     # Create the input arrays in device memory and copy data from host
-    d_field_x = cl.Buffer(context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=h_field_x)
-    d_field_y = cl.Buffer(context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=h_field_y)
-    d_field_t = cl.Buffer(context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=h_field_t)
-    d_field_U = cl.Buffer(context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=h_field_U)
-    d_field_V = cl.Buffer(context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=h_field_V)
-    d_x0 = cl.Buffer(context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=h_x0)
-    d_y0 = cl.Buffer(context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=h_y0)
-    d_t0 = cl.Buffer(context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=h_t0)
+    d_field_x, d_field_y, d_field_t, d_field_U, d_field_V, d_x0, d_y0, d_t0 = \
+        (cl.Buffer(context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=hostbuf)
+         for hostbuf in (h_field_x, h_field_y, h_field_t, h_field_U, h_field_V, h_x0, h_y0, h_t0))
     # Create the output arrays in device memory
     d_X_out = cl.Buffer(context, cl.mem_flags.READ_WRITE, h_X_out.nbytes)
     d_Y_out = cl.Buffer(context, cl.mem_flags.READ_WRITE, h_Y_out.nbytes)
     buf_time = time.time() - buf_time
 
+    # CHECK KERNEL ARGUMENTS
+    check_args(h_field_x, np.uint32(len(h_field_x)),
+               h_field_y, np.uint32(len(h_field_y)),
+               h_field_t, np.uint32(len(h_field_t)),
+               h_field_U, h_field_V,
+               h_x0, h_y0, h_t0,
+               np.float32(dt), np.uint32(num_timesteps), np.uint32(save_every),
+               h_X_out, h_Y_out)
+
     # Execute the kernel over the entire range of our 1d input
     # allowing OpenCL runtime to select the work group items for the device
+
     advect = program.advect
     advect.set_scalar_arg_dtypes([None, np.uint32, None, np.uint32, None, np.uint32,
                                   None, None,

--- a/src/opencl_specification_constants.py
+++ b/src/opencl_specification_constants.py
@@ -1,0 +1,11 @@
+"""
+It seems pyopencl doesn't give you access directly to the constants defined in the opencl specification, e.g. int_max.
+So unfortunately they're hard-coded here.  Raises error if the version of OpenCL doesn't match spec we're pulling these
+from (OpenCL 2.2)
+"""
+
+import pyopencl as cl
+
+assert cl.get_cl_header_version() == (2, 2), "This application requires OpenCL 2.2."
+
+UINT_MAX = 0xffffffff


### PR DESCRIPTION
In the 2d advection kernel, replaces the lazy for-loop nearest-neighbor finder with an O(1) lookup which takes advantage of a guarantee of ascending/uniform-spacing grids arrays.