### PR TITLE
Fixed typo from Lebreton 2012

### DIFF
--- a/src/kernels/advection_schemes.cl
+++ b/src/kernels/advection_schemes.cl
@@ -64,7 +64,7 @@ vector taylor2_displacement(particle p, grid_point gp, field2d field, double dt)
     //////////// advect particle using second-order taylor approx advection scheme (Black and Gay, 1990, eq. 12/13)
     vector displacement_meters;
     displacement_meters.x = (u_ + (uy*v_ - vy*u_) * dt/2) * dt / ((1 - ux*dt/2) * (1 - vy*dt/2) - (uy*vx * pow(dt, 2)) / 4);
-    displacement_meters.y = (v_ + (vx*u_ - ux*v_) * dt/2) * dt / ((1 - uy*dt/2) * (1 - vx*dt/2) - (ux*vy * pow(dt, 2)) / 4);
+    displacement_meters.y = (v_ + (vx*u_ - ux*v_) * dt/2) * dt / ((1 - ux*dt/2) * (1 - vy*dt/2) - (ux*vy * pow(dt, 2)) / 4);
 
     return displacement_meters;
 }

--- a/src/tests/circular_streamlines.py
+++ b/src/tests/circular_streamlines.py
@@ -3,16 +3,14 @@ The purpose of this test is to ensure that the second-order taylor kernel advect
 It should also show that the Eulerian kernel fails to do this.
 We will use a small latitude/longitude scale in order to approximate cartesian behavior.
 """
-from datetime import timedelta
-
 import numpy as np
 import xarray as xr
 import pandas as pd
+import matplotlib.pyplot as plt
+from datetime import timedelta
 
 from drivers.opencl_driver_2D import openCL_advect
-from kernel_wrappers.EulerianKernel2D import EulerianKernel2D
-from kernel_wrappers.Taylor2Kernel2D import Taylor2Kernel2D
-import matplotlib.pyplot as plt
+from kernel_wrappers.Kernel2D import AdvectionScheme
 
 
 def compare_alg_drift():
@@ -39,14 +37,14 @@ def compare_alg_drift():
 
     p0 = pd.DataFrame({'lon': [0], 'lat': [.005]})
     num_particles = 1
-    dt = timedelta(seconds=1)
+    dt = timedelta(seconds=30)
     time = pd.date_range(start='2000-01-01', end='2000-01-01T6:00:00', freq=dt)
     save_every = 1
 
-    euler, _, _ = openCL_advect(field=field, p0=p0, advect_time=time, save_every=save_every, kernel_class=EulerianKernel2D,
+    euler, _, _ = openCL_advect(field=field, p0=p0, advect_time=time, save_every=save_every, advection_scheme=AdvectionScheme.eulerian,
                                 platform_and_device=(0, 0), verbose=True)
 
-    taylor, _, _ = openCL_advect(field=field, p0=p0, advect_time=time, save_every=save_every,  kernel_class=Taylor2Kernel2D,
+    taylor, _, _ = openCL_advect(field=field, p0=p0, advect_time=time, save_every=save_every,  advection_scheme=AdvectionScheme.taylor2,
                                  platform_and_device=(0, 0), verbose=True)
 
     plt.figure(figsize=(8, 4))


### PR DESCRIPTION
Reading Tim's thesis, came across a note remarking that Lebreton 2012 second-order advection equations had a typo in the denom.  Indeed, and you can see Tim's results agree with Lebreton's citation, Black/Gay 1990.  Made the fix.  BUT, the fix made taylor2 perform worse than Euler.  Odd.  Perhaps a result of the major assumptions in the gradient approximation.  More likely that the incorrect equations just happen to perform well in a circular vector field than that they are actually better in general.  I mean, they aren't symmetrical if you look at them closely.  Also to note: Tim and Black/Gay still disagree about whether the dt in the third term of the denominator should be squared.  Answer from Tim about this pending.  Anyways here's the test with the worse result after the fix:
![drift_fixed](https://user-images.githubusercontent.com/11861183/96949870-a451e080-1484-11eb-8065-5f7d4d6b073a.png)
