### PR TITLE
implemented slippery coastlines

### DIFF
--- a/src/ECCO_advect_2D.py
+++ b/src/ECCO_advect_2D.py
@@ -3,11 +3,11 @@ advect on ECCO surface currents
 """
 
 from kernel_wrappers.Kernel2D import AdvectionScheme
-from plotting.plot_advection import plot_ocean_advection
+from plotting.plot_advection import plot_ocean_advection, plot_ocean_trajectories
 from run_advector import run_advector
 
-
-EDDY_DIFFUSIVITY = 1800  # m^2 / s
+#EDDY_DIFFUSIVITY = 1800  # m^2 / s
+EDDY_DIFFUSIVITY = 0  # m^2 / s
 ''' Sylvia Cole et al 2015: diffusivity calculated at a 300km eddy scale, global average in top 1000m, Argo float data.
   This paper shows 2 orders of magnitude variation regionally, not resolving regional differences is a big error source.
   Additionally, the assumption here is that 300km eddies are not resolved by the velocity field itself.  If they are,
@@ -19,7 +19,7 @@ EDDY_DIFFUSIVITY = 1800  # m^2 / s
 if __name__ == '__main__':
     out_path = run_advector(
         outputfile_path='../outputfiles/2015_ECCO.nc',
-        sourcefile_path='../sourcefiles/2015_uniform.nc',
+        sourcefile_path='../sourcefiles/small.nc',
         u_path='../forcing_data/ECCO/ECCO_interp/U*.nc',
         v_path='../forcing_data/ECCO/ECCO_interp/V*.nc',
         advection_start='2015-01-01T12',
@@ -31,4 +31,4 @@ if __name__ == '__main__':
         verbose=True,
     )
 
-    plot_ocean_advection(out_path)
+    plot_ocean_trajectories(out_path)

--- a/src/kernels/headers.cl
+++ b/src/kernels/headers.cl
@@ -6,6 +6,7 @@
 vector eulerian_displacement(particle p, grid_point neighbor, field2d field, double dt);
 vector taylor2_displacement(particle p, grid_point gp, field2d field, double dt);
 particle constrain_lat_lon(particle p);
+particle update_position_no_beaching(particle p, double dx, double dy, field2d field);
 particle update_position(particle p, double dx, double dy);
 void write_p(particle p, __global float *X_out, __global float *Y_out, unsigned int out_timesteps, unsigned int out_idx);
 grid_point find_nearest_neighbor(particle p, field2d field);
@@ -15,7 +16,7 @@ double degrees_lat_to_meters(double dy, double y);
 double degrees_lon_to_meters(double dx, double y);
 double meters_to_degrees_lon(double dx_meters, double y);
 double meters_to_degrees_lat(double dy_meters, double y);
-bool is_land(grid_point gp, field2d field);
+bool is_on_land(particle p, field2d field);
 double random(random_state *state);
 double eddy_diffusion_meters(const double dt, random_state *state, const double eddy_diffusivity);
 

--- a/src/plotting/plot_advection.py
+++ b/src/plotting/plot_advection.py
@@ -27,6 +27,17 @@ def plot_advection(P, time, field, streamfunc=True, ax=None):
         plt.pause(.01)
 
 
+def plot_ocean_trajectories(outputfile_path: str):
+    P = xr.open_dataset(outputfile_path)
+    # plot le advection
+    proj = ccrs.PlateCarree()
+    fig = plt.figure(figsize=[14, 8])
+    ax = plt.axes(projection=proj)
+    ax.coastlines()
+
+    ax.plot(P.lon.transpose('time', 'p_id'), P.lat.transpose('time', 'p_id'), '.')
+
+
 def plot_ocean_advection(outputfile_path: str, lon_range=(-180, 180), lat_range=(-90, 90)):
     P = xr.open_dataset(outputfile_path)
     # plot le advection


### PR DESCRIPTION
Tried to mimic behavior from trashtracker.  Basically, no particle is ever allowed to beach.  Period.  If a timestep pushes it onto land, the alg zeros out one (or both) of dx or dy, such that it does not beach.  Seems to work pretty well.  Implemented a little new plotting so trajectories can be visualized.

Note: future improvement is definitely to give advector a super high-res coastline file.  This could actually be committed straight to the repo and used regardless of forcing data.  However, seems like a change for the future.