### PR TITLE
fix chunking logic

### DIFF
--- a/examples/HYCOM_advect_2D.py
+++ b/examples/HYCOM_advect_2D.py
@@ -11,7 +11,7 @@ U_WATER_PATH = "./HYCOM_currents/uv*2015*.nc"
 V_WATER_PATH = "./HYCOM_currents/uv*2015*.nc"
 U_WIND_PATH = "./MERRA2_wind/*2015*.nc"
 V_WIND_PATH = "./MERRA2_wind/*2015*.nc"
-SOURCEFILE_PATH = "./sourcefiles/big.nc"
+SOURCEFILE_PATH = "./sourcefiles/2015_uniform_two_releases.nc"
 OUTPUTFILE_PATH = "./outputfiles/HYCOM_2015_out.nc"
 
 ADVECTION_START = datetime(2015, 1, 1)
@@ -39,7 +39,7 @@ if __name__ == '__main__':
         eddy_diffusivity=EDDY_DIFFUSIVITY,
         verbose=True,
         # source_file_type=SourceFileType.trashtracker,  # uncomment for trashtracker source files
-        memory_utilization=.95,  # decrease if RAM overloaded.  Can be close to 1 on dedicated compute device (e.g. GPU)
+        memory_utilization=.4,  # decrease if RAM overloaded.  Can be close to 1 on dedicated compute device (e.g. GPU)
     )
 
     plot_ocean_advection(out_path)


### PR DESCRIPTION
Issue #31.  The chunking logic re: memory calculations was not taking into account that the particle output array would be split into chunks as well.  How I overlooked this is beyond me.  This fixes, tested on my local GPU with 2GB memory, .95 utilization, so 1900MB effective RAM:
```Chunk   1/16: 2015-01-01T00:00:00.000000000 to 2015-01-23T00:00:00.000000000...
  Loading currents and wind...
[########################################] | 100% Completed |  1.6s
[########################################] | 100% Completed |  1.6s
-----MEMORY FOOTPRINT-----
Current:              1656.880 MB
Wind:                    0.000 MB
Particle Positions:    192.000 MB
Total:                1848.880 MB
------EXECUTION TIME------
Kernel Execution:        8.159 s
Memory Read/Write:       0.165 s```