### PR TITLE
Make Kernel Robust to NaNs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 __pycache__
 examples/MERRA2_wind/MERRA2*
 examples/HYCOM_currents/*.nc
+examples/outputfiles/*tmp
+examples/outputfiles/*.nc
+examples/sourcefiles/*.nc
 .DS_Store
 .idea

--- a/src/drivers/advection_chunking.py
+++ b/src/drivers/advection_chunking.py
@@ -67,6 +67,7 @@ def estimate_memory_bytes(current: xr.Dataset, wind: xr.Dataset, num_particles: 
                      8 * (len(current.lon) + len(current.lat) + len(current.time)))  # the 3 64-bit coordinate arrays
     wind_bytes = (2 * 4 * np.prod(wind.U.shape) +  # two 32-bit fields
                   8 * (len(wind.lon) + len(wind.lat) + len(wind.time)))  # the 3 64-bit coordinate arrays
-    output_bytes = 2 * 4 * num_particles * out_timesteps   # two 32-bit variables for each particle for each timestep
+    output_bytes = (2 * 4 * num_particles * out_timesteps +  # two 32-bit variables for each particle for each timestep
+                    1 * num_particles)  # one byte holding error code for each particle
     p0_bytes = 2 * 4 * num_particles  # two 32-bit variables for each particle
     return (current_bytes+wind_bytes), output_bytes, p0_bytes

--- a/src/drivers/opencl_driver_2D.py
+++ b/src/drivers/opencl_driver_2D.py
@@ -8,6 +8,7 @@ import xarray as xr
 import pandas as pd
 import os
 import shutil
+import warnings
 
 from typing import Tuple, Optional
 from dask.diagnostics import ProgressBar
@@ -39,7 +40,7 @@ def openCL_advect(current: xr.Dataset,
                  Dimensions: {'time', 'lon', 'lat'}
                  Variables: {'U', 'V'}
     :param out_path: path at which to save the outputfile
-    :param p0: initial positions of particles, pandas dataframe with columns ['lon', 'lat', 'release_date']
+    :param p0: initial positions of particles, pandas dataframe with columns ['p_id', 'lon', 'lat', 'release_date']
     :param start_time: advection start time
     :param dt: timestep duration
     :param num_timesteps: number of timesteps
@@ -93,6 +94,9 @@ def openCL_advect(current: xr.Dataset,
                                    dt=dt, start_time=advect_time_chunk[0], num_timesteps=num_timesteps_chunk, save_every=save_every,
                                    out_timesteps=out_timesteps_chunk)
         kernel.execute()
+        error_message = kernel.report_errors(p0_chunk.p_id.values)
+        if error_message:
+            warnings.warn(error_message, RuntimeWarning)
 
         buf_time += kernel.buf_time
         kernel_time += kernel.kernel_time
@@ -101,6 +105,7 @@ def openCL_advect(current: xr.Dataset,
             kernel.print_execution_time()
 
         P_chunk = create_dataset_from_kernel(kernel=kernel,
+                                             p_id=p0_chunk.p_id.values,
                                              release_date=p0_chunk.release_date,
                                              advect_time=out_time_chunk)
         
@@ -109,7 +114,7 @@ def openCL_advect(current: xr.Dataset,
 
         writer.write_output_chunk(P_chunk)
 
-        p0_chunk = P_chunk.isel(time=-1).to_dataframe()
+        p0_chunk = P_chunk.isel(time=-1).to_dataframe().reset_index()  # move p_id from index to column
         # problem is, this ^ has nans for location of all the unreleased particles.  Restore that information here
         p0_chunk.loc[p0_chunk.release_date > advect_time_chunk[-1], ['lat', 'lon']] = p0[['lat', 'lon']]
 
@@ -150,7 +155,7 @@ def create_kernel(advection_scheme: AdvectionScheme, eddy_diffusivity: float, wi
     )
 
 
-def create_dataset_from_kernel(kernel: Kernel2D, release_date: np.ndarray, advect_time: pd.DatetimeIndex) -> xr.Dataset:
+def create_dataset_from_kernel(kernel: Kernel2D, p_id: np.ndarray, release_date: np.ndarray, advect_time: pd.DatetimeIndex) -> xr.Dataset:
     """assumes kernel has been run"""
     num_particles = len(kernel.x0)
     lon = kernel.X_out.reshape([num_particles, -1])
@@ -159,7 +164,7 @@ def create_dataset_from_kernel(kernel: Kernel2D, release_date: np.ndarray, advec
     P = xr.Dataset(data_vars={'lon': (['p_id', 'time'], lon),
                               'lat': (['p_id', 'time'], lat),
                               'release_date': (['p_id'], release_date)},
-                   coords={'p_id': np.arange(num_particles),
+                   coords={'p_id': p_id,
                            'time': advect_time[1:]}  # initial positions are not returned
                    )
     return P

--- a/src/kernel_wrappers/Kernel2D.py
+++ b/src/kernel_wrappers/Kernel2D.py
@@ -62,6 +62,9 @@ class Kernel2D:
         self.buf_time = 0
         self.kernel_time = 0
 
+        # debugging
+        self.error_codes = np.zeros_like(self.x0, dtype=np.ubyte)
+
     def execute(self):
         """tranfers arguments to the compute device, triggers execution, waits on result"""
         # write arguments to compute device
@@ -76,6 +79,7 @@ class Kernel2D:
               self.x0, self.y0, self.release_date))
         d_X_out = cl.Buffer(self.context, cl.mem_flags.READ_WRITE | cl.mem_flags.COPY_HOST_PTR, hostbuf=self.X_out)
         d_Y_out = cl.Buffer(self.context, cl.mem_flags.READ_WRITE | cl.mem_flags.COPY_HOST_PTR, hostbuf=self.Y_out)
+        d_error_codes = cl.Buffer(self.context, cl.mem_flags.READ_WRITE | cl.mem_flags.COPY_HOST_PTR, hostbuf=self.error_codes)
         self.buf_time = time.time() - write_start
 
         # execute the program
@@ -87,7 +91,8 @@ class Kernel2D:
                  None, None, None,
                  np.float64, np.float64, np.uint32, np.uint32,
                  None, None,
-                 np.uint32, np.float64, np.float64])
+                 np.uint32, np.float64, np.float64,
+                 None])
         execution_start = time.time()
         self.cl_kernel(
                 self.queue, (len(self.x0),), None,
@@ -103,7 +108,8 @@ class Kernel2D:
                 np.float64(self.start_time), np.float64(self.dt),
                 np.uint32(self.ntimesteps), np.uint32(self.save_every),
                 d_X_out, d_Y_out,
-                np.uint32(self.advection_scheme.value), np.float64(self.eddy_diffusivity), np.float64(self.windage_coeff))
+                np.uint32(self.advection_scheme.value), np.float64(self.eddy_diffusivity), np.float64(self.windage_coeff),
+                d_error_codes)
 
         # wait for the computation to complete
         self.queue.finish()
@@ -113,6 +119,7 @@ class Kernel2D:
         read_start = time.time()
         cl.enqueue_copy(self.queue, self.X_out, d_X_out)
         cl.enqueue_copy(self.queue, self.Y_out, d_Y_out)
+        cl.enqueue_copy(self.queue, self.error_codes, d_error_codes)
         self.buf_time += time.time() - read_start
 
     def print_memory_footprint(self):
@@ -167,10 +174,22 @@ class Kernel2D:
         assert is_uniformly_spaced(self.wind_t)
 
         # check particle positions valid
+        assert not any(np.isnan(self.x0))
         assert max(self.x0) < 180
         assert min(self.x0) >= -180
+        assert not any(np.isnan(self.y0))
         assert max(self.y0) <= 90
         assert min(self.y0) >= -90
 
         # check enum valid
         assert self.advection_scheme.value in (0, 1)
+
+    def report_errors(self, particle_ids: np.ndarray):
+        if not np.all(self.error_codes == 0):
+            error_str = f"{np.count_nonzero(self.error_codes)} particle(s) did not exit successfully."
+            for i, code in enumerate(self.error_codes[self.error_codes != 0]):
+                error_str += f"\n Particle ID {particle_ids[i]} exited with error code {code}."
+                # look to kernel_2d.cl for error code definitions
+            return error_str
+        else:
+            return ""

--- a/src/kernels/fields.cl
+++ b/src/kernels/fields.cl
@@ -1,9 +1,12 @@
 #include "fields.h"
 
 unsigned int find_nearest_neighbor_idx(double value, __global const double *arr, const unsigned int arr_len, const double spacing) {
-    // assumption: arr is sorted with uniform spacing.  Actually works on ascending or descending sorted arr.
-    // also, we must have arr_len - 1 <= UINT_MAX for the cast of the clamp result to behave properly.  Can't raise errors
-    // inside a kernel so we must perform the check in the host code.
+    /* assumptions:
+        -- arr is sorted with uniform spacing.  Actually works on ascending or descending sorted arr.
+        -- we must have arr_len - 1 <= UINT_MAX for the cast of the clamp result to behave properly.  Can't raise errors
+            inside a kernel so we must perform the check in the host code.
+        -- value MUST be non-nan.  This function produces UNDEFINED BEHAVIOR if value is nan.
+    */
     return (unsigned int) clamp(round((value - arr[0])/spacing), (double) (0.0), (double) (arr_len-1));
 }
 

--- a/src/kernels/kernel_2d.cl
+++ b/src/kernels/kernel_2d.cl
@@ -7,6 +7,8 @@
 #include "eddy_diffusion.cl"
 #include "windage.cl"
 
+enum ExitCode {SUCCESS = 0, FAILURE = 1, INVALID_ADVECTION_SCHEME = 2, NULL_LOCATION = 3};
+
 __kernel void advect(
     /* current vector field */
     __global const double *current_x,    // lon, Deg E (-180 to 180), uniform spacing
@@ -41,8 +43,13 @@ __kernel void advect(
     /* physics parameters */
     const unsigned int advection_scheme,
     const double eddy_diffusivity,
-    const double windage_coeff)  // if nan, disables windage
+    const double windage_coeff,  // if nan, disables windage
+    /* debugging utility */
+    __global unsigned char *exit_codes)
 {
+    int global_id = get_global_id(0);
+    exit_codes[global_id] = FAILURE;  // unless noted otherwise...
+
     const unsigned int out_timesteps = ntimesteps / save_every;
 
     field2d current = {.x = current_x, .y = current_y, .t = current_t,
@@ -60,13 +67,18 @@ __kernel void advect(
                     .U = wind_U, .V = wind_V};
 
     // loop timesteps
-    int global_id = get_global_id(0);
     particle p = {.id = global_id, .x = x0[global_id], .y = y0[global_id], .t = start_time};
     random_state rstate = {.a = ((unsigned int) p.id) + 1};  // for eddy diffusivity; must be unique across kernels, and nonzero.
     for (unsigned int timestep=0; timestep<ntimesteps; timestep++) {
         if (p.t < release_date[p.id]) {  // wait until the particle is released to start advecting and writing output
             p.t += dt;
             continue;
+        }
+
+        // quit if particle has null location, this is a disallowed state
+        if (isnan(p.x) || isnan(p.y)) {
+            exit_codes[global_id] = NULL_LOCATION;
+            return;
         }
 
         if (is_on_land(p, current)) {
@@ -78,7 +90,8 @@ __kernel void advect(
             } else if (advection_scheme == TAYLOR2) {
                 displacement_meters = taylor2_displacement(p, current, dt);
             } else {
-                return;  // can't throw errors but at least this way things will obviously fail
+                exit_codes[global_id] = INVALID_ADVECTION_SCHEME;
+                return;  // complete execution
             }
 
             displacement_meters = add(displacement_meters, eddy_diffusion_meters(dt, &rstate, eddy_diffusivity));
@@ -98,4 +111,5 @@ __kernel void advect(
             write_p(p, X_out, Y_out, out_timesteps, out_idx);
         }
     }
+    exit_codes[global_id] = SUCCESS;
 }

--- a/src/kernels/particle.cl
+++ b/src/kernels/particle.cl
@@ -63,6 +63,7 @@ void write_p(particle p, __global float *X_out, __global float *Y_out, unsigned 
 }
 
 grid_point find_nearest_neighbor(particle p, field2d field) {
+/* assumption: particle has non-null latitude and longitude. */
         grid_point neighbor;
         neighbor.x_idx = find_nearest_neighbor_idx(p.x, field.x, field.x_len, field.x_spacing);
         neighbor.y_idx = find_nearest_neighbor_idx(p.y, field.y, field.y_len, field.y_spacing);


### PR DESCRIPTION
We've been having a nasty hardware specific crash on Cartesius.  Cause is still unknown, but it was discovered that p.lat or p.lon becoming nan COULD be crashing things in a hardware-dependent way.  The frequently used function
```
grid_point find_nearest_neighbor(particle p, field2d field) {
        grid_point neighbor;
        neighbor.x_idx = find_nearest_neighbor_idx(p.x, field.x, field.x_len, field.x_spacing);
        neighbor.y_idx = find_nearest_neighbor_idx(p.y, field.y, field.y_len, field.y_spacing);
        neighbor.t_idx = find_nearest_neighbor_idx(p.t, field.t, field.t_len, field.t_spacing);
        return neighbor;
}
```
Receives a particle, and passes its lat/lon/t on to find_nearest_neighbor_idx:
```
unsigned int find_nearest_neighbor_idx(double value, __global const double *arr, const unsigned int arr_len, const double spacing) {
    // assumption: arr is sorted with uniform spacing.  Actually works on ascending or descending sorted arr.
    // also, we must have arr_len - 1 <= UINT_MAX for the cast of the clamp result to behave properly.  Can't raise errors
    // inside a kernel so we must perform the check in the host code.
    return (unsigned int) clamp(round((value - arr[0])/spacing), (double) (0.0), (double) (arr_len-1));
}
```


Looking at the opencl specification closely, it appears clamp(nan, minvalue, maxvalue) will return nan.  So indeed, find_nearest_neighbor_idx(nan, ...) will return (unsigned int) nan which is undefined.  Since this index will then be used to grab values out of the vector field, this undefined (read: hardware-dependent) behavior could have big implications for whether the program silently runs happily along (if, say, (unsigned int) nan == 0), or whether it tries to read off the end of the array, producing, again, undefined behavior, or perhaps a segfault.

It is unclear whether this badness is causing the crash; however, it should be fixed regardless.  The way to fix it is to EXPLICITLY note that find_nearest_neighbor_idx requires `value` to be non-null.  Then, usages of this function will be changed to satisfy this requirement.  I wish we could add an `assert` into the function, but can't do that in opencl.  Diligent code and good comments are thus the solution.