### PR TITLE
Speed up output writing

### DIFF
--- a/src/io_tools/write_to_outputfile.py
+++ b/src/io_tools/write_to_outputfile.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import xarray as xr
+import netCDF4 as nc
+import numpy as np
+
+
+class OutputWriter:
+    def __init__(self, out_path: Path):
+        self.path = out_path
+        self.created = False
+
+    def write_output_chunk(self, chunk: xr.Dataset):
+        if not self.created:
+            self._write_first_chunk(chunk)
+            self.created = True
+        else:
+            self._append_chunk(chunk)
+
+    def _write_first_chunk(self, chunk: xr.Dataset):
+        with nc.Dataset(self.path, mode="w") as ds:
+            ds.createDimension("time", None)  # unlimited dimension
+            ds.createDimension("p_id", len(chunk.p_id))
+
+            time = ds.createVariable("time", np.float64, ("time",))
+            time.units = "seconds since 1970-01-01 00:00:00.0"
+            time.calendar = "gregorian"
+            time[:] = chunk.time.values.astype('datetime64[s]').astype(np.float64)
+
+            p_id = ds.createVariable("p_id", chunk.p_id.dtype, ("p_id",))
+            p_id[:] = chunk.p_id.values
+
+            lon = ds.createVariable("lon", chunk.lon.dtype, ("p_id", "time"))
+            lon.units = "Degrees East"
+            lon[:] = chunk.lon.values
+
+            lat = ds.createVariable("lat", chunk.lat.dtype, ("p_id", "time"))
+            lat.units = "Degrees North"
+            lat[:] = chunk.lat.values
+
+            release_date = ds.createVariable("release_date", np.float64, ("p_id",))
+            release_date.units = "seconds since 1970-01-01 00:00:00.0"
+            release_date.calendar = "gregorian"
+            release_date[:] = chunk.release_date.values.astype('datetime64[s]').astype(np.float64)
+
+    def _append_chunk(self, chunk: xr.Dataset):
+        with nc.Dataset(self.path, mode="a") as ds:
+            time = ds.variables['time']
+            start_t = len(time)
+            time[start_t:] = chunk.time.values.astype('datetime64[s]').astype(np.float64)
+
+            lon = ds.variables['lon']
+            lon[:, start_t:] = chunk.lon.values
+
+            lat = ds.variables['lat']
+            lat[:, start_t:] = chunk.lat.values


### PR DESCRIPTION
Addresses issue #32. Wrote an appender that uses the python netcdf4 library to write each chunk to disk in a streaming fashion.  First chunk is written pretty standardly, then after that each chunk is opened in "append" mode, and extended along the time dimension.  Presumably much faster, removes the kluge of temp files and concatenating everything at the end.