### PR TITLE
standardize sourcefile and outputfile naming

### DIFF
--- a/examples/sourcefiles/generate_sourcefile.py
+++ b/examples/sourcefiles/generate_sourcefile.py
@@ -31,8 +31,8 @@ def generate_sourcefile(
     p0['release_date'] = np.concatenate((np.full(num_particles//2, np.datetime64('2015-01-01T12')),
                                         np.full(num_particles//2 + num_particles % 2, np.datetime64('2015-06-01'))))
 
-    p0['id'] = np.arange(num_particles)
-    ds = xr.Dataset(p0.set_index('id'))
+    p0['p_id'] = np.arange(num_particles)
+    ds = xr.Dataset(p0.set_index('p_id'))
 
     ds.to_netcdf(out_path)
 

--- a/src/io_tools/open_sourcefiles.py
+++ b/src/io_tools/open_sourcefiles.py
@@ -14,7 +14,7 @@ class SourceFileType(Enum):
     advector = 1
 
 
-SOURCEFILE_VARIABLES = ['id', 'lon', 'lat', 'release_date']
+SOURCEFILE_VARIABLES = ['p_id', 'lon', 'lat', 'release_date']
 
 
 def datenum_to_datetimeNS64(datenum):
@@ -42,21 +42,21 @@ def open_sourcefiles(
     """
     :param sourcefile_path: path to the particle sourcefile netcdf file.  Absolute path safest, use relative paths with caution.
     :param variable_mapping: mapping from names in sourcefile to advector standard variable names
-            advector standard names: ('id', 'lat', 'lon', 'release_date')
+            advector standard names: ('p_id', 'lat', 'lon', 'release_date')
     :param source_file_type: specify what sourcefile we have.
     """
     if variable_mapping is None:
         variable_mapping = {}
     if source_file_type == SourceFileType.trashtracker:  # merge defaults with passed map, passed map wins conflicts
-        default_mapping = {'releaseDate': 'release_date', 'x': 'id'}
+        default_mapping = {'releaseDate': 'release_date', 'x': 'p_id'}
         variable_mapping = dict(default_mapping, **variable_mapping)
 
     # Need to make sure we concat along the right dim. If there's a mapping, use it to get the name of the axis.
-    # If the "id" coordinate is properly defined (i.e both a variable and a dimension), this shouldn't be necessary.
-    if 'id' not in variable_mapping.values():
-        concat_dim = "id"
+    # If the "p_id" coordinate is properly defined (i.e both a variable and a dimension), this shouldn't be necessary.
+    if 'p_id' not in variable_mapping.values():
+        concat_dim = "p_id"
     else:
-        concat_dim = next(k for k, v in variable_mapping.items() if v == 'id')
+        concat_dim = next(k for k, v in variable_mapping.items() if v == 'p_id')
 
     sourcefile = xr.open_mfdataset(
         glob.glob(sourcefile_path),
@@ -70,10 +70,10 @@ def open_sourcefiles(
     dims = list(sourcefile.dims.keys())
     assert len(dims) == 1, "sourcefile has more than one dimension."
 
-    if 'id' not in dims:
+    if 'p_id' not in dims:
         sourcefile = sourcefile.to_dataframe()
     else:
-        sourcefile = sourcefile.to_dataframe().reset_index()  # move id from index to column
+        sourcefile = sourcefile.to_dataframe().reset_index()  # move p_id from index to column
 
     for var in SOURCEFILE_VARIABLES:
         assert var in sourcefile.columns, f"missing variable '{var}'.  If differently named, pass in mapping."

--- a/src/run_advector.py
+++ b/src/run_advector.py
@@ -50,7 +50,7 @@ def run_advector(
     :param save_period: how often to write output.  Particle state will be saved every {save_period} timesteps.
     :param source_file_type: enum of what format source file is input
     :param sourcefile_varname_map: mapping from names in sourcefile to advector standard variable names
-            advector standard names: ('id', 'lat', 'lon', 'release_date')
+            advector standard names: ('p_id', 'lat', 'lon', 'release_date')
     :param currents_varname_map: mapping from names in current file to advector standard variable names
             advector standard names: ('U', 'V', 'W', 'lat', 'lon', 'time', 'depth')
     :param platform_and_device: [index of opencl platform, index of opencl device] to specify hardware for computation


### PR DESCRIPTION
currently, sourcefile coordinate variable is 'id', while in outputfiles it is 'p_id'.  Noticed this while writing documentation.  That's pretty bogus, so I'm standardizing to 'p_id.'  A little more descriptive than 'id', and I think 'particle_id' is a little overkill.  Users should know these files contain particles, probably would be annoying in postprocessing to be always typing out 'particle_id'.  But you're doing post-processing, Axel, so let me know if you disagree!