### PR TITLE
kernel support for singleton dimensions

### DIFF
--- a/src/kernel_wrappers/Kernel2D.py
+++ b/src/kernel_wrappers/Kernel2D.py
@@ -41,8 +41,8 @@ class Kernel2D:
             self.wind_x, self.wind_y, self.wind_t = wind_x, wind_y, wind_t
             self.wind_U, self.wind_V = wind_U, wind_V
         else:  # opencl won't pass totally empty arrays to the kernel.  Windage disabled, so array contents don't matter
-            self.wind_x, self.wind_y, self.wind_t = [np.arange(2)] * 3
-            self.wind_U, self.wind_V = [np.zeros((2, 2, 2))] * 2
+            self.wind_x, self.wind_y, self.wind_t = [np.zeros(1, dtype=np.float64)] * 3
+            self.wind_U, self.wind_V = [np.zeros((1, 1, 1), dtype=np.float32)] * 2
             self.windage_coeff = np.nan  # to flag the kernel that windage is disabled
         self.x0, self.y0, self.release_date = x0, y0, release_date
         self.start_time, self.dt, self.ntimesteps, self.save_every = start_time, dt, ntimesteps, save_every
@@ -145,25 +145,25 @@ class Kernel2D:
         # check current field valid
         assert max(self.current_x) <= 180
         assert min(self.current_x) >= -180
-        assert 2 <= len(self.current_x) <= cl_const.UINT_MAX + 1
+        assert 1 <= len(self.current_x) <= cl_const.UINT_MAX + 1
         assert is_uniformly_spaced(self.current_x)
         assert max(self.current_y) <= 90
         assert min(self.current_y) >= -90
-        assert 2 <= len(self.current_y) <= cl_const.UINT_MAX + 1
+        assert 1 <= len(self.current_y) <= cl_const.UINT_MAX + 1
         assert is_uniformly_spaced(self.current_y)
-        assert 2 <= len(self.current_t) <= cl_const.UINT_MAX + 1
+        assert 1 <= len(self.current_t) <= cl_const.UINT_MAX + 1
         assert is_uniformly_spaced(self.current_t)
 
         # check wind field valid
         assert max(self.wind_x) <= 180
         assert min(self.wind_x) >= -180
-        assert 2 <= len(self.wind_x) <= cl_const.UINT_MAX + 1
+        assert 1 <= len(self.wind_x) <= cl_const.UINT_MAX + 1
         assert is_uniformly_spaced(self.wind_x)
         assert max(self.wind_y) <= 90
         assert min(self.wind_y) >= -90
-        assert 2 <= len(self.wind_y) <= cl_const.UINT_MAX + 1
+        assert 1 <= len(self.wind_y) <= cl_const.UINT_MAX + 1
         assert is_uniformly_spaced(self.wind_y)
-        assert 2 <= len(self.wind_t) <= cl_const.UINT_MAX + 1
+        assert 1 <= len(self.wind_t) <= cl_const.UINT_MAX + 1
         assert is_uniformly_spaced(self.wind_t)
 
         # check particle positions valid

--- a/src/kernels/fields.cl
+++ b/src/kernels/fields.cl
@@ -4,7 +4,11 @@ unsigned int find_nearest_neighbor_idx(double value, __global const double *arr,
     // assumption: arr is sorted with uniform spacing.  Actually works on ascending or descending sorted arr.
     // also, we must have arr_len - 1 <= UINT_MAX for the cast of the clamp result to behave properly.  Can't raise errors
     // inside a kernel so we must perform the check in the host code.
-    return (unsigned int) clamp(round((value - arr[0])/spacing), (double) (0.0), (double) (arr_len-1));
+    if (arr_len == 1 || spacing == 0) {  // handles singletons and protects against division by zero
+        return 0;
+    } else {
+        return (unsigned int) clamp(round((value - arr[0])/spacing), (double) (0.0), (double) (arr_len-1));
+    }
 }
 
 vector index_vector_field(field2d field, grid_point gp, bool zero_nans) {

--- a/src/kernels/kernel_2d.cl
+++ b/src/kernels/kernel_2d.cl
@@ -10,20 +10,20 @@
 __kernel void advect(
     /* current vector field */
     __global const double *current_x,    // lon, Deg E (-180 to 180), uniform spacing
-    const unsigned int current_x_len,   // 2 <= current_x_len <= UINT_MAX + 1
+    const unsigned int current_x_len,   // 1 <= current_x_len <= UINT_MAX + 1
     __global const double *current_y,    // lat, Deg N (-90 to 90), uniform spacing
-    const unsigned int current_y_len,   // 2 <= current_y_len <= UINT_MAX + 1
+    const unsigned int current_y_len,   // 1 <= current_y_len <= UINT_MAX + 1
     __global const double *current_t,     // time, seconds since epoch, uniform spacing
-    const unsigned int current_t_len,   // 2 <= current_t_len <= UINT_MAX + 1
+    const unsigned int current_t_len,   // 1 <= current_t_len <= UINT_MAX + 1
     __global const float *current_U,    // m / s, 32 bit to save space
     __global const float *current_V,    // m / s
     /* wind vector field */
     __global const double *wind_x,    // lon, Deg E (-180 to 180), uniform spacing
-    const unsigned int wind_x_len,   // 2 <= wind_x_len <= UINT_MAX + 1
+    const unsigned int wind_x_len,   // 1 <= wind_x_len <= UINT_MAX + 1
     __global const double *wind_y,    // lat, Deg N (-90 to 90), uniform spacing
-    const unsigned int wind_y_len,   // 2 <= wind_y_len <= UINT_MAX + 1
+    const unsigned int wind_y_len,   // 1 <= wind_y_len <= UINT_MAX + 1
     __global const double *wind_t,     // time, seconds since epoch, uniform spacing
-    const unsigned int wind_t_len,   // 2 <= wind_t_len <= UINT_MAX + 1
+    const unsigned int wind_t_len,   // 1 <= wind_t_len <= UINT_MAX + 1
     __global const float *wind_U,    // m / s, 32 bit to save space
     __global const float *wind_V,    // m / s
     /* particle initialization information */
@@ -47,16 +47,16 @@ __kernel void advect(
 
     field2d current = {.x = current_x, .y = current_y, .t = current_t,
                      .x_len = current_x_len, .y_len = current_y_len, .t_len = current_t_len,
-                     .x_spacing = current_x[1]-current_x[0],
-                     .y_spacing = current_y[1]-current_y[0],
-                     .t_spacing = current_t[1]-current_t[0],
+                     .x_spacing = (current_x[current_x_len-1]-current_x[0])/current_x_len,
+                     .y_spacing = (current_y[current_y_len-1]-current_y[0])/current_y_len,
+                     .t_spacing = (current_t[current_t_len-1]-current_t[0])/current_t_len,
                      .U = current_U, .V = current_V};
 
     field2d wind = {.x = wind_x, .y = wind_y, .t = wind_t,
                     .x_len = wind_x_len, .y_len = wind_y_len, .t_len = wind_t_len,
-                    .x_spacing = wind_x[1]-wind_x[0],
-                    .y_spacing = wind_y[1]-wind_y[0],
-                    .t_spacing = wind_t[1]-wind_t[0],
+                    .x_spacing = (wind_x[wind_x_len-1]-wind_x[0])/wind_x_len,
+                    .y_spacing = (wind_y[wind_y_len-1]-wind_y[0])/wind_y_len,
+                    .t_spacing = (wind_t[wind_t_len-1]-wind_t[0])/wind_t_len,
                     .U = wind_U, .V = wind_V};
 
     // loop timesteps


### PR DESCRIPTION
As I've worked on 3D, I've realized that supporting singleton dimensions is pretty important, because this way we can represent 2D arrays as 3D arrays with a singleton depth.  Also, there was no reason not to support them other than laziness.  Why not allow advection on, for example, a field that doesn't change in time?  This PR also provides protection against division by zero in the find_nearest_neighbor_index function.  If spacing==0, this means every value in the array has the same value, and so returning index 0 is a valid solution.