### PR TITLE
WIP : Make it work on distributed architectures

### DIFF
--- a/src/drivers/opencl_driver_2D.py
+++ b/src/drivers/opencl_driver_2D.py
@@ -6,8 +6,6 @@ import pyopencl as cl
 import numpy as np
 import xarray as xr
 import pandas as pd
-import os
-import shutil
 
 from typing import Tuple, Optional
 from dask.diagnostics import ProgressBar
@@ -28,7 +26,7 @@ def openCL_advect(current: xr.Dataset,
                   eddy_diffusivity: float,
                   windage_coeff: Optional[float],
                   memory_utilization: float,
-                  platform_and_device: Tuple[int] = None,
+                  platform_and_device: Tuple[str] = None,
                   verbose=False) -> Tuple[float, float]:
     """
     advect particles on device using OpenCL.  Dynamically chunks computation to fit device memory.

--- a/src/run_advector.py
+++ b/src/run_advector.py
@@ -29,7 +29,7 @@ def run_advector(
     source_file_type: SourceFileType = SourceFileType.advector,
     sourcefile_varname_map: dict = None,
     currents_varname_map: Optional[dict] = None,
-    platform_and_device: Tuple[int, ...] = None,
+    platform_and_device: Tuple[str, ...] = None,
     verbose: bool = False,
     memory_utilization: float = 0.5,
     u_wind_path: Optional[str] = None,


### PR DESCRIPTION
The input should actually be ['0','0'] where each number, even if string, represents the device to use.
The advantage of this is to be able to create a context that uses multiple devices at once with ['0','0,1']. That will use the first platform with the 2 GPUs available.
And it works already, just needed to change the typing there