### PR TITLE
Sort inputs before starting ADVECTOR

### DIFF
--- a/src/io_tools/open_sourcefiles.py
+++ b/src/io_tools/open_sourcefiles.py
@@ -59,7 +59,7 @@ def open_sourcefiles(
         concat_dim = next(k for k, v in variable_mapping.items() if v == 'p_id')
 
     sourcefile = xr.open_mfdataset(
-        glob.glob(sourcefile_path),
+        sorted(glob.glob(sourcefile_path)),
         parallel=True,
         combine="nested",
         concat_dim=concat_dim


### PR DESCRIPTION
Had a discussion with Yannick, and down the road after ADVECTOR it's easier to have the particles in the same order as release
Doesn't cost a thing computationally, so let's do it.