### PR TITLE
Constrain Diffusion to Surface

### DIFF
--- a/examples/ECCO_advect_3D.py
+++ b/examples/ECCO_advect_3D.py
@@ -6,7 +6,7 @@ from plotting.plot_advection import animate_ocean_advection
 from run_advector import run_advector
 from datetime import datetime, timedelta
 
-EDDY_DIFFUSIVITY = 0  # 1800  # m^2 / s
+EDDY_DIFFUSIVITY = 1800  # m^2 / s
 ''' Sylvia Cole et al 2015: diffusivity calculated at a 300km eddy scale, global average in top 1000m, Argo float data.
   This paper shows 2 orders of magnitude variation regionally, not resolving regional differences is a big error source.
   Additionally, the assumption here is that 300km eddies are not resolved by the velocity field itself.  If they are,
@@ -23,16 +23,16 @@ if __name__ == '__main__':
         u_water_path='ECCO/ECCO_interp/U_2015*.nc',
         v_water_path='ECCO/ECCO_interp/V_2015*.nc',
         w_water_path='ECCO/ECCO_interp/W_2015*.nc',
-        # u_wind_path='MERRA2_wind/*2015*.nc',
-        # v_wind_path='MERRA2_wind/*2015*.nc',
-        # windfile_varname_map={'ULML': 'U', 'VLML': 'V'},
+        u_wind_path='MERRA2_wind/*2015*.nc',
+        v_wind_path='MERRA2_wind/*2015*.nc',
+        wind_varname_map={'ULML': 'U', 'VLML': 'V'},
         advection_start_date=datetime(year=2015, month=1, day=1, hour=12),
         timestep=timedelta(hours=1),
         num_timesteps=24*365,
         save_period=24,
         advection_scheme='eulerian',
         eddy_diffusivity=EDDY_DIFFUSIVITY,
-        # windage_coeff=WINDAGE_COEFF,
+        windage_coeff=WINDAGE_COEFF,
         verbose=True,
         opencl_device=(0, 2),
         memory_utilization=.95,

--- a/src/kernels/eddy_diffusion.cl
+++ b/src/kernels/eddy_diffusion.cl
@@ -1,9 +1,15 @@
 #include "eddy_diffusion.h"
 
-vector eddy_diffusion_meters(const double dt, random_state *state, const double eddy_diffusivity) {
-    /* returns random walk in meters*/
-    vector diff = {.x = (random(state) * 2 - 1) * sqrt(6 * eddy_diffusivity * dt),
-                   .y = (random(state) * 2 - 1) * sqrt(6 * eddy_diffusivity * dt),
-                   .z = 0};
+vector eddy_diffusion_meters(double z, const double dt, random_state *state, const double eddy_diffusivity) {
+    /*
+    Currently, only horizontal diffusion at the surface is supported.
+    This diffusion is represented by a random displacement, the magnitude of which is determined
+    by the "eddy_diffusivity" parameter.
+    */
+    vector diff = {.x = 0, .y = 0, .z = 0};
+    if (z >= MINIMUM_SURFACE_DIFFUSION_DEPTH) {
+        diff.x = (random(state) * 2 - 1) * sqrt(6 * eddy_diffusivity * dt);
+        diff.y = (random(state) * 2 - 1) * sqrt(6 * eddy_diffusivity * dt);
+    }
     return diff;
 }

--- a/src/kernels/eddy_diffusion.h
+++ b/src/kernels/eddy_diffusion.h
@@ -4,6 +4,8 @@
 #include "random.h"
 #include "vector.h"
 
-vector eddy_diffusion_meters(const double dt, random_state *state, const double eddy_diffusivity);
+#define MINIMUM_SURFACE_DIFFUSION_DEPTH -1  // depth below which horizontal surface diffusion does not apply
+
+vector eddy_diffusion_meters(double z, const double dt, random_state *state, const double eddy_diffusivity);
 
 #endif // EDDY_DIFFUSION

--- a/src/kernels/kernel_3d.cl
+++ b/src/kernels/kernel_3d.cl
@@ -104,7 +104,7 @@ __kernel void advect(
                 return;
             }
 
-            displacement_meters = add(displacement_meters, eddy_diffusion_meters(dt, &rstate, eddy_diffusivity));
+            displacement_meters = add(displacement_meters, eddy_diffusion_meters(p.z, dt, &rstate, eddy_diffusivity));
             if (!isnan(windage_coeff)) {
                 displacement_meters = add(displacement_meters, windage_meters(p, wind, dt, windage_coeff));
             }

--- a/src/plotting/plot_advection.py
+++ b/src/plotting/plot_advection.py
@@ -39,7 +39,7 @@ def animate_ocean_advection(outputfile_path: str, lon_range=(-180, 180), lat_ran
     trunc_winter = mcol.ListedColormap(cm.winter(np.linspace(0, .8, 100)))
 
     dot = ax.scatter(np.zeros(len(P.p_id)), np.zeros(len(P.p_id)), c=np.zeros(len(P.p_id)), cmap=trunc_winter,
-                     s=5, norm=mcol.Normalize(vmin=P.depth.min(), vmax=P.depth.max()))
+                     s=5, norm=mcol.Normalize(vmin=-100, vmax=0))
     cbar = plt.colorbar(mappable=dot, ax=ax)
     cbar.ax.set_ylabel('Depth (m)')
 


### PR DESCRIPTION
Cutoff set at 1m depth to deactivate these effects.  This is basically because we want v1 to be able to support surface advection the same as V0, and we aren't going to delve into subsurface diffusion / wind driven mixing in v1.0.

Note: Wind already constrained to surface.