### PR TITLE
Check field variable exists before indexing into it

### DIFF
--- a/src/kernels/fields.cl
+++ b/src/kernels/fields.cl
@@ -36,9 +36,10 @@ vector index_vector_field(field3d field, grid_point gp, bool zero_nans) {
     assumption: gp.[dim]_idx args will be in [0, field.[dim]_len - 1]
     optional: if zero_nans, any nans encountered will be replaced with zero.  useful for advection schemes.
     */
-    vector V = {.x = field.U[(((gp.t_idx*field.z_len) + gp.z_idx)*field.x_len + gp.x_idx)*field.y_len + gp.y_idx],
-                .y = field.V[(((gp.t_idx*field.z_len) + gp.z_idx)*field.x_len + gp.x_idx)*field.y_len + gp.y_idx],
-                .z = field.W[(((gp.t_idx*field.z_len) + gp.z_idx)*field.x_len + gp.x_idx)*field.y_len + gp.y_idx]};
+    size_t flat_index = (((gp.t_idx*field.z_len) + gp.z_idx)*field.x_len + gp.x_idx)*field.y_len + gp.y_idx;
+    vector V = {.x = field.U ? field.U[flat_index] : NAN, // these ternary expressions serve to stop indexing into
+                .y = field.V ? field.V[flat_index] : NAN, // an undefined variable
+                .z = field.W ? field.V[flat_index] : NAN};
     if (zero_nans) {
         if (isnan(V.x)) V.x = 0;
         if (isnan(V.y)) V.y = 0;

--- a/src/kernels/kernel_3d.cl
+++ b/src/kernels/kernel_3d.cl
@@ -74,7 +74,7 @@ __kernel void advect(
                     .x_spacing = (wind_x[wind_x_len-1]-wind_x[0])/wind_x_len,
                     .y_spacing = (wind_y[wind_y_len-1]-wind_y[0])/wind_y_len,
                     .t_spacing = (wind_t[wind_t_len-1]-wind_t[0])/wind_t_len,
-                    .U = wind_U, .V = wind_V};
+                    .U = wind_U, .V = wind_V, .W = 0};
 
     // loop timesteps
     particle p = {.id = global_id, .x = x0[global_id], .y = y0[global_id], .z = z0[global_id], .t = start_time};


### PR DESCRIPTION
Title.  In the kernel, our field3ds can have up to 3 fields (U, V, W) but it's useful to not define these, e.g. wind only has U/V, in the future we'll want to represent bathymetry which will be a 2d field with only 1 variable.  I suspect this could have already been causing crashes with trying to index W on the wind data; not sure why it wasn't.