### PR TITLE
Remove trashtracker sourcefile support

### DIFF
--- a/src/data_specifications.md
+++ b/src/data_specifications.md
@@ -1,10 +1,7 @@
 # Data Specifications
 
 ## Sourcefiles
-Source files contain the initial state of particles, and are encoded as netcdf datasets.  Two formats of sourcefile are accepted: advector (default, native), and trashtracker (legacy support).
-
-### Advector Sourcefiles
-Advector sourcefiles adhere to the following dataset structure:
+Source files contain the initial state of particles, and are encoded as netcdf datasets.  They adhere to the following dataset structure:
 
 #### Dimensions
 
@@ -25,24 +22,6 @@ Advector sourcefiles adhere to the following dataset structure:
 | corey_shape_factor | (p_id) | numeric | Represents the shape of the particle.  Defined as c/sqrt(a*b), where a, b, and c are the longest, intermediate, and shortest perpendicular dimensions of the particle. |
 | release_date | (p_id) | datetime (CF- or ISO-compliant) | timestamp at which particle enters simulation |
 
-### TrashTracker Sourcefiles
-Trashtracker sourcefiles adhere to the following dataset structure:
-
-#### Dimensions
-
-| Name | Data Type | Description |
-| --- | --- | --- |
-| x | integer | indexes particles |
-
-#### Variables
-
-| Name | Dimensions | Data Type | Description |
-| --- | --- | --- | --- |
-| id | (x) | integer | numeric id of particle |
-| lon | (x) | numeric | initial longitude of particle, degrees E, any domain (will be coerced to [-180, 180) |
-| lat | (x) | numeric | initial latitude of particle, degrees N, domain [-90, 90] |
-| releaseDate | (x) | numeric, Matlab 'datenum' representation | timestamp at which particle enters simulation |
-| unsd | (x) | integer | UNSD M49 country code.  Currently ignored. |
 ## Outputfiles
 Outputfiles contain the particle trajectories computed by the model, as well as metadata which describe in detail the configuration of ADVECTOR which produced them.  They adhere to the following specifications:
 

--- a/src/io_tools/open_sourcefiles.py
+++ b/src/io_tools/open_sourcefiles.py
@@ -1,55 +1,25 @@
 from datetime import datetime
 from datetime import timedelta
-from enum import Enum
 import glob
 from typing import Optional
 
 import xarray as xr
 import pandas as pd
 
-
-class SourceFileFormat(Enum):
-    """Allows to handle different type of source files."""
-    trashtracker = 0
-    advector = 1
-
-
 SOURCEFILE_VARIABLES = {'p_id', 'lon', 'lat', 'depth', 'radius', 'density', 'corey_shape_factor', 'release_date'}
-
-
-def datenum_to_datetimeNS64(datenum):
-    """
-    Convert Matlab datenum into Python datetime64[ns]
-    :param datenum: Date in datenum format
-    :return:        Datetime object corresponding to datenum.
-    """
-
-    # Matlab datenum goes down to Jan 0 of year 0, but Python datetime only goes down to Jan 1 year 1
-    # On top of that, the representation of datetime64 in nanoseconds cannot go before 1678 and after 2262 approx.
-
-    if datenum > 612513: 
-        days = datenum % 1
-        return datetime.fromordinal(int(datenum)) + timedelta(days=days) - timedelta(days=366)
-    else:
-        return datetime(1678, 1, 1, 1, 1, 1, 1)
 
 
 def open_sourcefiles(
     sourcefile_path: str,
     variable_mapping: Optional[dict],
-    source_file_type: SourceFileFormat,
 ) -> xr.Dataset:
     """
     :param sourcefile_path: path to the particle sourcefile netcdf file.  Absolute path safest, use relative paths with caution.
     :param variable_mapping: mapping from names in sourcefile to advector standard variable names
             advector standard names: ('p_id', 'lat', 'lon', 'depth', 'release_date')
-    :param source_file_type: specify what sourcefile we have.
     """
     if variable_mapping is None:
         variable_mapping = {}
-    if source_file_type == SourceFileFormat.trashtracker:  # merge defaults with passed map, passed map wins conflicts
-        default_mapping = {'releaseDate': 'release_date', 'x': 'p_id', 'id': 'p_id'}
-        variable_mapping = dict(default_mapping, **variable_mapping)
 
     # Need to make sure we concat along the right dim. If there's a mapping, use it to get the name of the axis.
     # If the "p_id" coordinate is properly defined (i.e both a variable and a dimension), this shouldn't be necessary.
@@ -72,10 +42,6 @@ def open_sourcefiles(
 
     for var in SOURCEFILE_VARIABLES:
         assert var in sourcefile.variables, f"missing variable '{var}'.  If differently named, pass in mapping."
-
-    if source_file_type == SourceFileFormat.trashtracker:
-        sourcefile['release_date'] = pd.to_datetime(sourcefile['release_date'].apply(datenum_to_datetimeNS64))
-        sourcefile['lon'] = ((sourcefile.lon + 180) % 360) - 180  # enforce [-180, 180] longitude
 
     sourcefile.load()  # persist into RAM
 

--- a/src/run_advector.py
+++ b/src/run_advector.py
@@ -16,7 +16,7 @@ from drivers.opencl_driver_3D import openCL_advect
 from io_tools.OutputWriter import OutputWriter
 from io_tools.open_configfiles import load_eddy_diffusivity, load_density_profile
 from kernel_wrappers.Kernel3D import AdvectionScheme
-from io_tools.open_sourcefiles import SourceFileFormat, open_sourcefiles
+from io_tools.open_sourcefiles import open_sourcefiles
 from io_tools.open_vectorfiles import open_2D_vectorfield, empty_2D_vectorfield, open_3D_vectorfield
 
 
@@ -32,7 +32,6 @@ def run_advector(
     num_timesteps: int,
     advection_scheme: str = 'taylor2',
     save_period: int = 1,
-    sourcefile_format: str = 'advector',
     sourcefile_varname_map: dict = None,
     water_varname_map: dict = None,
     opencl_device: Tuple[int, ...] = None,
@@ -66,7 +65,6 @@ def run_advector(
         "eulerian" is the forward Euler method.
     :param save_period: controls how often to write output: particle state will be saved every {save_period} timesteps.
         For example, with timestep=one hour, and save_period=24, the particle state will be saved once per day.
-    :param sourcefile_format: one of {"advector", "trashtracker"}.  See data_specifications.md for more details.
     :param sourcefile_varname_map: mapping from names in sourcefile to standard names, as defined in
         data_specifications.md.  E.g. {"longitude": "lon", "particle_release_time": "release_date", ...}
     :param water_varname_map: mapping from names in current files to standard names.  See 'sourcefile_varname_map'.
@@ -94,16 +92,10 @@ def run_advector(
     except KeyError:
         raise ValueError(f"Invalid argument advection_scheme; must be one of "
                          f"{set(scheme.name for scheme in AdvectionScheme)}.")
-    try:
-        sourcefile_format_enum = SourceFileFormat[sourcefile_format]
-    except KeyError:
-        raise ValueError(f"Invalid argument sourcefile_format; must be one of "
-                         f"{set(fmt.name for fmt in SourceFileFormat)}.")
 
     p0 = open_sourcefiles(
         sourcefile_path=sourcefile_path,
         variable_mapping=sourcefile_varname_map,
-        source_file_type=sourcefile_format_enum,
     )
 
     currents = open_3D_vectorfield(


### PR DESCRIPTION
not much to say here, spoke with @axelpey and seems like this legacy support doesn't belong in this codebase, both because trashtracker sourcefiles are for a 2d model, and so do not apply to a 3d model, and because supporting them encourages reliance on legacy sourcefile-generating code which should probably be updated anyways.

A negative diff?  Ooooooweee