### PR TITLE
Fix bug preventing particle release if release date near end of chunk

### DIFF
--- a/src/drivers/opencl_driver_2D.py
+++ b/src/drivers/opencl_driver_2D.py
@@ -112,7 +112,7 @@ def openCL_advect(current: xr.Dataset,
 
         p0_chunk = P_chunk.isel(time=-1).to_dataframe().reset_index()  # move p_id from index to column
         # problem is, this ^ has nans for location of all the unreleased particles.  Restore that information here
-        p0_chunk.loc[p0_chunk.release_date > advect_time_chunk[-1], ['lat', 'lon']] = p0[['lat', 'lon']]
+        p0_chunk.loc[p0_chunk.release_date > advect_time_chunk[-2], ['lat', 'lon']] = p0[['lat', 'lon']]
 
     return writer.paths
 


### PR DESCRIPTION
Found an OBO bug which was causing some particles to never get properly released.

In theory this fix would cause a crash if len(advect_time_chunk) < 2, but this should never be the case.  If it is, there's other problems at hand.

If your release dates are randomly distributed, before this fix you would expect to see some small percent of particles to fail in the kernel due to "NULL_LOCATION" error; this is because they aren't identified as unreleased, so their sourcefile location isn't passed into the kernel, instead their latest location is.  And their latest location is nan, because they were never released.