### PR TITLE
Only load kernel source code once.

### DIFF
--- a/src/kernel_wrappers/Kernel.py
+++ b/src/kernel_wrappers/Kernel.py
@@ -48,9 +48,9 @@ class Kernel(ABC):
         # create opencl objects
         self.context = context
         self.queue = cl.CommandQueue(context)
-        self.cl_kernel = cl.Program(
-            context, open(self._kernel_source_path).read()
-        ).build(options=["-I", str(self._model_core_path)])
+        self.cl_kernel = cl.Program(context, self._kernel_source_code).build(
+            options=["-I", str(self._model_core_path)]
+        )
 
         # some handy timers
         self.data_load_time = 0
@@ -63,7 +63,7 @@ class Kernel(ABC):
 
     @property
     @abstractmethod
-    def _kernel_source_path(self):
+    def _kernel_source_code(self) -> str:
         pass
 
     @abstractmethod

--- a/src/kernel_wrappers/Kernel2D.py
+++ b/src/kernel_wrappers/Kernel2D.py
@@ -14,6 +14,9 @@ from kernel_wrappers.Field3D import Field3D, create_empty_2d_field, buffer_from_
 from kernel_wrappers.Kernel import Kernel, KernelConfig
 
 
+KERNEL2D_SOURCE = open(Path(__file__).parent.parent / "kernels/kernel_2d.cl").read()
+
+
 @dataclass
 class Kernel2DConfig(KernelConfig):
     """Configuration for 2D Kernel.
@@ -196,5 +199,5 @@ class Kernel2D(Kernel):
         assert self.config.advection_scheme.value in (0, 1)
 
     @property
-    def _kernel_source_path(self):
-        return Path(__file__).parent.parent / "kernels/kernel_2d.cl"
+    def _kernel_source_code(self) -> str:
+        return KERNEL2D_SOURCE

--- a/src/kernel_wrappers/Kernel3D.py
+++ b/src/kernel_wrappers/Kernel3D.py
@@ -20,6 +20,9 @@ from kernel_wrappers.Field3D import (
 from kernel_wrappers.Kernel import Kernel, KernelConfig
 
 
+KERNEL3D_SOURCE = open(Path(__file__).parent.parent / "kernels/kernel_3d.cl").read()
+
+
 @dataclass
 class Kernel3DConfig(KernelConfig):
     """Configuration for 3D Kernel.
@@ -288,5 +291,5 @@ class Kernel3D(Kernel):
             )
 
     @property
-    def _kernel_source_path(self):
-        return Path(__file__).parent.parent / "kernels/kernel_3d.cl"
+    def _kernel_source_code(self) -> str:
+        return KERNEL3D_SOURCE


### PR DESCRIPTION
Addresses issue #51.  Before, kernel source code was read from disk when each chunk is executing.  This means you could modify kernel behavior partway through a run!  Gross.