### PR TITLE
Reformatting with Black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Cython and C extensions
+*.so
+*.c
+*.h
+*.html
+
+# Distribution / packaging
+.Python
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+.miniforge3/
+miniforge3/
+siteconf.py
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+cover/
+.cache
+.idea/
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+# Sphinx documentation
+docs/_build/
+

--- a/tests/integration_tests/test_circular_drift.py
+++ b/tests/integration_tests/test_circular_drift.py
@@ -24,7 +24,7 @@ lon = np.linspace(-0.02, 0.02, nx * 2)  # .01 degrees at equator ~= 1 km
 lat = np.linspace(-0.01, 0.01, nx)
 
 LON, LAT = np.meshgrid(lon, lat)
-mag = np.sqrt(LON ** 2 + LAT ** 2)
+mag = np.sqrt(LON**2 + LAT**2)
 U = np.divide(-LAT, mag, out=np.zeros_like(LON), where=mag != 0)
 V = np.divide(LON, mag, out=np.zeros_like(LON), where=mag != 0)
 
@@ -188,11 +188,11 @@ def test_circular_drift_2d():
 
     # taylor stays within 5% of radius on average
     np.testing.assert_allclose(
-        np.sqrt(taylor.lon ** 2 + taylor.lat ** 2).mean(), initial_radius, rtol=0.05
+        np.sqrt(taylor.lon**2 + taylor.lat**2).mean(), initial_radius, rtol=0.05
     )
 
     # euler spirals out wildly
-    assert np.sqrt(euler.lon ** 2 + euler.lat ** 2)[-1] > initial_radius * 1.5
+    assert np.sqrt(euler.lon**2 + euler.lat**2)[-1] > initial_radius * 1.5
 
 
 def test_circular_drift_3d():
@@ -201,11 +201,11 @@ def test_circular_drift_3d():
 
     # taylor stays within 5% of radius on average
     np.testing.assert_allclose(
-        np.sqrt(taylor.lon ** 2 + taylor.lat ** 2).mean(), initial_radius, rtol=0.05
+        np.sqrt(taylor.lon**2 + taylor.lat**2).mean(), initial_radius, rtol=0.05
     )
 
     # euler spirals out wildly
-    assert np.sqrt(euler.lon ** 2 + euler.lat ** 2)[-1] > initial_radius * 1.5
+    assert np.sqrt(euler.lon**2 + euler.lat**2)[-1] > initial_radius * 1.5
 
 
 if __name__ == "__main__":

--- a/tests/src/model_core/test_buoyancy.py
+++ b/tests/src/model_core/test_buoyancy.py
@@ -81,7 +81,7 @@ def test_kooi_2016(plot=False):
     size_small = np.linspace(0.5e-3, 1.5e-3, nsamples)
     volume_small = (
         0.5 * size_small
-    ) * size_small ** 2  # we assume short dimension is .5 of long dimension
+    ) * size_small**2  # we assume short dimension is .5 of long dimension
     r_small = np.cbrt(3 / (4 * np.pi) * volume_small)
     v_small_mean = 0.009  # m/s
     v_small_std = 0.004  # m/s
@@ -91,7 +91,7 @@ def test_kooi_2016(plot=False):
     )  # again, size means the long dimension
     volume_big = (
         0.25 * size_big
-    ) * size_big ** 2  # now we assume short dimension is .25 of long dimension
+    ) * size_big**2  # now we assume short dimension is .25 of long dimension
     r_big = np.cbrt(3 / (4 * np.pi) * volume_big)
     v_big_mean = 0.019  # m/s
     v_big_std = 0.006  # m/s

--- a/tests/src/model_core/test_random.py
+++ b/tests/src/model_core/test_random.py
@@ -163,7 +163,7 @@ def test_standard_normal():
     # validate distribution shape
     measured_PDF, bin_edges = np.histogram(result, bins=20, range=(-3, 3), density=True)
     bin_centers = bin_edges[:-1] + np.diff(bin_edges)[0] / 2
-    true_PDF = 1 / np.sqrt(2 * np.pi) * np.exp(-0.5 * bin_centers ** 2)
+    true_PDF = 1 / np.sqrt(2 * np.pi) * np.exp(-0.5 * bin_centers**2)
     np.testing.assert_allclose(true_PDF, measured_PDF, atol=0.01)
 
 

--- a/tests/src/model_core/test_wind_driven_mixing.py
+++ b/tests/src/model_core/test_wind_driven_mixing.py
@@ -149,7 +149,7 @@ def test_calculate_significant_wave_height():
     # we can get wind stress from this, and calculate wave height, to at least do a sanity check
     water_density = 1025  # kg m^-3
     wind_stress = (
-        0.75e-2 ** 2 * water_density
+        0.75e-2**2 * water_density
     )  # m/s  inverting kukulka's given frictional water velocity
     wave_height = calculate_significant_wave_height(wind_stress)
     assert 0 < wave_height < 1  # sanity range check

--- a/tests/src/model_core/test_windage.py
+++ b/tests/src/model_core/test_windage.py
@@ -61,7 +61,7 @@ def test_calculate_windage_coeff():
     np.testing.assert_allclose(
         calculate_windage_coeff(r=r, z=z),
         np.sqrt(
-            density_ratio * drag_ratio * emerged_area / (np.pi * r ** 2 - emerged_area)
+            density_ratio * drag_ratio * emerged_area / (np.pi * r**2 - emerged_area)
         ),
     )
 
@@ -103,7 +103,7 @@ def circular_segment_area(R, r) -> np.ndarray:
 
 def test_circular_segment_area():
     # split in half
-    np.testing.assert_allclose(circular_segment_area(R=1, r=0), np.pi * 1 ** 2 / 2)
+    np.testing.assert_allclose(circular_segment_area(R=1, r=0), np.pi * 1**2 / 2)
 
     # tangent line (no segment)
     np.testing.assert_allclose(circular_segment_area(R=1, r=1), 0)
@@ -112,12 +112,12 @@ def test_circular_segment_area():
     R, r = 10, 8
     theta = 2 * np.arccos(r / R)
     np.testing.assert_allclose(
-        circular_segment_area(R=R, r=r), 0.5 * R ** 2 * (theta - np.sin(theta))
+        circular_segment_area(R=R, r=r), 0.5 * R**2 * (theta - np.sin(theta))
     )
 
     # major segment
     R, r = 5, -1
     theta = 2 * np.arccos(r / R)
     np.testing.assert_allclose(
-        circular_segment_area(R=R, r=r), 0.5 * R ** 2 * (theta - np.sin(theta))
+        circular_segment_area(R=R, r=r), 0.5 * R**2 * (theta - np.sin(theta))
     )


### PR DESCRIPTION
In line with recent commits (https://github.com/TheOceanCleanupAlgorithms/ADVECT/commit/2ec4aee88a96951174953a88006173b2f549df83), I reformatted the unit tests with the most recent version of the `black` linter.

(Also, I added a basic Python `.gitignore` file, to keep the Git work area clean after you run unit tests.)